### PR TITLE
Support for packages that provide others.

### DIFF
--- a/arch-ppa
+++ b/arch-ppa
@@ -34,8 +34,10 @@ install_system_deps() {
 	set -e
 	pkg_dep() {
 	    if !(pacman -Q $1 > /dev/null 2>&1); then
-		echo "Installing $1..."
-		exe sudo pacman -S --noconfirm $1
+	    	if !(pacman -Qsq ^$1\$ > /dev/null); then
+			echo "Installing $1..."
+			exe sudo pacman -S --noconfirm $1
+		fi
 	    fi
 	}
 	pkg_dep devtools


### PR DESCRIPTION
A small change from a similar script I have to support packages like gcc-multilib (because if you just check for gcc, pacman -Q will not find anything).